### PR TITLE
alpha v3 release

### DIFF
--- a/Office365PowerShellUtils_mod.psm1
+++ b/Office365PowerShellUtils_mod.psm1
@@ -838,7 +838,14 @@ function Connect-Office365 {
                     Write-Warning -Message "Exchange not loaded.  Currently no none MFA connection to Exchange Online available, skipping connection to Exchange Online"
                 }
             } else {
-                Connect-ExchangeOnline
+                # https://david-homer.blogspot.com/2025/01/exchange-online-management-powershell.html
+                $msalPath = [System.IO.Path]::GetDirectoryName((Get-Module ExchangeOnlineManagement).Path);
+                Add-Type -Path "$msalPath\Microsoft.IdentityModel.Abstractions.dll";
+                Add-Type -Path "$msalPath\Microsoft.Identity.Client.dll";
+                [Microsoft.Identity.Client.IPublicClientApplication] $application = [Microsoft.Identity.Client.PublicClientApplicationBuilder]::Create("fb78d390-0c51-40cd-8e17-fdbfab77341b").WithDefaultRedirectUri().Build();
+                $result = $application.AcquireTokenInteractive([string[]]"https://outlook.office365.com/.default").ExecuteAsync().Result;
+                Connect-ExchangeOnline -AccessToken $result.AccessToken -UserPrincipalName $result.Account.Username; 
+                # Connect-ExchangeOnline
             }
         }
 

--- a/Office365PowerShellUtils_mod.psm1
+++ b/Office365PowerShellUtils_mod.psm1
@@ -743,17 +743,36 @@ function Clear-MailboxMemberOf {
     }
 }
 
+# TODO: This cmdlet needs more documentation, better parameter settings and better error checking.
 function Connect-Office365 {
 	[CmdletBinding(SupportsShouldProcess=$false, DefaultParameterSetName="Username")]
 	Param(
 		[Parameter(Mandatory=$false,ParameterSetName="Username",HelpMessage="Credentials")]
-		    [String]$Username,
+		    [String] $Username,
 		[Parameter(Mandatory=$false,ParameterSetName="Credentials",HelpMessage="Credentials")]
-		    [System.Management.Automation.PSCredential]$Credential,
+		    [System.Management.Automation.PSCredential] $Credential,
         [Parameter(Mandatory=$false,ParameterSetName="CredentialsFile", HelpMessage="Path to credentials")]
-            [String]$CredentialPath,
-        [Parameter(Mandatory=$false, HelpMessage="To use MFA with ExchangeOnline v2")]
-            [Switch]$UseMFA
+            [String] $CredentialPath,
+        [Parameter(Mandatory=$false)]
+            [String] $CertificateFilePath,
+        [Parameter(Mandatory=$false)]
+            [SecureString] $CertificatePassword,
+        [Parameter(Mandatory=$false)]
+            [String] $CertificateThumbPrint,
+        [Parameter(Mandatory=$false)]
+            [String] $AppID,
+        [Parameter(Mandatory=$false)]
+            [String] $Organization,
+        [Parameter(Mandatory=$false)]
+            [Switch] $AvoidMFA,
+        [Parameter(Mandatory=$false)]
+            [Switch] $SkipSharePoint,
+        [Parameter(Mandatory=$false)]
+            [Switch] $SkipExchange,
+        [Parameter(Mandatory=$false)]
+            [Switch] $SkipTeams,
+        [Parameter(Mandatory=$false)]
+            [Switch] $SkipComplianceCenter
     )
     
     Process {
@@ -773,11 +792,49 @@ function Connect-Office365 {
         #Connect to MSOLService with credential
         Connect-MsolService -Credential $Credential
 
+        #Connect to SharePoint
+        if (!$SkipSharePoint) {
+            Connect-SPOService -Credential $Credential
+        }
+
+        #Connect to Teams
+        if (!$SkipTeams) {
+            Connect-MicrosoftTeams -Credential $Credential
+        }
+
         #Connect to Exchange Online
-        if ($UseMFA) {
-            Connect-ExchangeOnline -UserPrincipalName $Credential.UserName
-        } else {
-            Connect-ExchangeOnline -Credential $Credential
+        if (!$SkipExchange) {
+            <# Support for connection via certificate
+            See https://docs.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps
+            and https://docs.microsoft.com/en-us/azure/automation/shared-resources/certificates
+            #>
+            if ($AvoidMFA -or $AppID) {
+                if ($AppID) {
+                    if ($CertificateFilePath) {
+                        Connect-ExchangeOnline -CertificateFilePath $CertificateFilePath -CertificatePassword $CertificatePassword -AppId $AppID -Organization $Organization
+                    } elseif ($CertificateThumbPrint) {
+                        Connect-ExchangeOnline -CertificateThumbprint $CertificateThumbPrint -AppId $AppID -Organization $Organization
+                    } else {
+                        Write-Warning "Exchange not loaded.  CertificateFilePath or CertificateThumbprint required.  See https://docs.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps"
+                    }
+                } else {
+                    # Connect another way?  The old way?  Essentialy if AvoidMFA, this currently is same as SkipExchange.
+                    Write-Warning -Message "Exchange not loaded.  Currently no none MFA connection to Exchange Online available, skipping connection to Exchange Online"
+                }
+            } else {
+                Connect-ExchangeOnline -UserPrincipalName $Credential.UserName
+            }
+        }
+
+        if (!$SkipComplianceCenter) {
+            # IPPSSession supports both MFA and basic connect
+            if ($AvoidMFA) {
+                # Basic
+                Connect-IPPSSession -Credential $Credential
+            } else {
+                # MFA
+                Connect-IPPSSession -UserPrincipalName $Credential.UserName
+            }
         }
     }
 }

--- a/Office365PowershellUtils.psd1
+++ b/Office365PowershellUtils.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '3.0.0.5'
+ModuleVersion = '3.0.0.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Office365PowershellUtils.psd1
+++ b/Office365PowershellUtils.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '2.0.0.1'
+ModuleVersion = '3.0.0.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -51,9 +51,7 @@ PowerShellVersion = '3.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('MSOnline', 
-               'ActiveDirectory', 
-               'ExchangeOnlineManagement')
+RequiredModules = @('ActiveDirectory','MSOnline','ExchangeOnlineManagement','MicrosoftTeams', 'Microsoft.Online.SharePoint.PowerShell')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
@@ -127,7 +125,7 @@ PrivateData = @{
         # RequireLicenseAcceptance = $false
 
         # External dependent modules of this module
-        ExternalModuleDependencies = @('ActiveDirectory','MSOnline')
+        ExternalModuleDependencies = @('ActiveDirectory','MSOnline','ExchangeOnlineManagement','MicrosoftTeams', 'Microsoft.Online.SharePoint.PowerShell')
 
     } # End of PSData hashtable
 

--- a/Office365PowershellUtils.psd1
+++ b/Office365PowershellUtils.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '3.0.0.1'
+ModuleVersion = '3.0.0.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -51,7 +51,7 @@ PowerShellVersion = '3.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('ActiveDirectory','MSOnline','ExchangeOnlineManagement','MicrosoftTeams', 'Microsoft.Online.SharePoint.PowerShell')
+# RequiredModules = @('ActiveDirectory','MSOnline','ExchangeOnlineManagement','MicrosoftTeams', 'Microsoft.Online.SharePoint.PowerShell')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
@@ -125,7 +125,7 @@ PrivateData = @{
         # RequireLicenseAcceptance = $false
 
         # External dependent modules of this module
-        ExternalModuleDependencies = @('ActiveDirectory','MSOnline','ExchangeOnlineManagement','MicrosoftTeams', 'Microsoft.Online.SharePoint.PowerShell')
+        # ExternalModuleDependencies = @('ActiveDirectory','MSOnline','ExchangeOnlineManagement','MicrosoftTeams', 'Microsoft.Online.SharePoint.PowerShell')
 
     } # End of PSData hashtable
 


### PR DESCRIPTION
Skipping up to v3.  Re-write of Connect-Office365 with following changes:

- Removed Skype for Business connector
- Upgraded to Exchange Online Management v2 module
- Support for certificate-based login to Exchange Online v2
- Added MS Teams
- Upgraded Safety & Compliance connection to use Exchange Online Management module